### PR TITLE
Addind end_to_end_id to incoming payments

### DIFF
--- a/lib/modulr/resources/payments/payment.rb
+++ b/lib/modulr/resources/payments/payment.rb
@@ -4,7 +4,7 @@ module Modulr
   module Resources
     module Payments
       class Payment < Base
-        attr_reader :details
+        attr_reader :details, :end_to_end_id
 
         map :id, [:id, :payment_reference_id]
         map :status
@@ -17,6 +17,38 @@ module Modulr
         def initialize(raw_response, attributes = {})
           super(raw_response, attributes)
           @details = parse_details(attributes)
+          @end_to_end_id = if incoming_sepa?(attributes)
+                             sepa_end_to_end_id(attributes)
+                           elsif incoming_faster_payments?(attributes)
+                             faster_payments_end_to_end_id(attributes)
+                           end
+        end
+
+        private def incoming_sepa?(attributes)
+          %w[PI_SECT PI_SEPA_INST].include?(attributes[:details]&.dig(:type))
+        end
+
+        private def incoming_faster_payments?(attributes)
+          attributes[:details]&.dig(:type) == "PI_FAST"
+        end
+
+        private def sepa_end_to_end_id(attributes)
+          doc = attributes[:details].dig(:details, :payload, :docs, :doc)
+          return unless doc
+
+          doc_type = doc.dig(:header, :type)
+          key = doc_type.downcase.to_sym
+
+          case doc_type
+          when "IFCCTRNS" # SEPA instant
+            doc.dig(key, :document, :fitoFICstmrCdtTrf, :cdtTrfTxInf, :pmtId, :endToEndId)
+          when "FFCCTRNS" # SEPA regular
+            doc.dig(key, :document, :fitoFICstmrCdtTrf, :cdtTrfTxInf).first&.dig(:pmtId, :endToEndId)
+          end
+        end
+
+        private def faster_payments_end_to_end_id(attributes)
+          attributes[:details].dig(:details, :fpsTransaction, :paymentInfo, :endToEndId)
         end
 
         private def parse_details(attributes)

--- a/spec/fixtures/payments/create/responses/success.http
+++ b/spec/fixtures/payments/create/responses/success.http
@@ -16,4 +16,4 @@ x-ratelimit-remaining: 3999900
 x-ratelimit-reset: 1674464655
 x-xss-protection: 1; mode=block
 
-{"id":"P210FFRUVT","status":"VALIDATED","createdDate":"2023-01-20T08:46:23.023+0000","externalReference":"The external reference","details":{"sourceAccountId":"A21BZ2GE","destinationType":"IBAN","destination":{"type":"IBAN","iban":"ES6015632626303264517956","name":"Aitor García Rey"},"currency":"EUR","amount":0.02,"reference":"The reference"},"reference":"P210FFRUVT","approvalStatus":"NOTNEEDED"}
+{"id":"P210FFRUVT","status":"VALIDATED","createdDate":"2023-01-20T08:46:23.023+0000","externalReference":"The external reference","details":{"sourceAccountId":"A21BZ2GE","destinationType":"IBAN","destination":{"type":"IBAN","iban":"ES8731902527103498957662","name":"Aitor García Rey"},"currency":"EUR","amount":0.02,"reference":"The reference"},"reference":"P210FFRUVT","approvalStatus":"NOTNEEDED"}

--- a/spec/fixtures/payments/find/incoming/responses/success_sepa_inst.http
+++ b/spec/fixtures/payments/find/incoming/responses/success_sepa_inst.http
@@ -43,7 +43,7 @@ x-xss-protection: 1; mode=block
           "name": "Aitor Garcia Rey",
           "identifier": {
             "type": "IBAN",
-            "iban": "ES6015632626303264517956",
+            "iban": "ES8731902527103498957662",
             "bic": "NTSBESM1XXX"
           }
         },
@@ -110,7 +110,7 @@ x-xss-protection: 1; mode=block
                           "id": { "iban": "IE21MODR99035502154595" }
                         },
                         "dbtrAcct": {
-                          "id": { "iban": "ES6015632626303264517956" }
+                          "id": { "iban": "ES8731902527103498957662" }
                         },
                         "accptncDtTm": 1.679303811468e9,
                         "intrBkSttlmAmt": { "ccy": "EUR", "value": 2.0 }

--- a/spec/fixtures/payments/find/incoming/responses/success_sepa_regular.http
+++ b/spec/fixtures/payments/find/incoming/responses/success_sepa_regular.http
@@ -19,45 +19,188 @@ x-xss-protection: 1; mode=block
 {
   "content": [
     {
-      "id": "P1200AJ55X",
+      "id": "P210H5Z0KK",
       "status": "PROCESSED",
-      "createdDate": "2023-04-11T16:16:20.020+0000",
+      "createdDate": "2023-03-21T11:14:35.035+0000",
       "details": {
-        "created": "2023-04-11T16:16:20.733+00:00",
+        "created": "2023-03-21T11:14:35.131+00:00",
         "retryCount": 0,
         "sourceService": "bolProviderService",
-        "requestReference": "SI23032029385314",
+        "requestReference": "S230800054197732",
         "reprocess": false,
         "priority": 0,
-        "accountNumber": "A1216A1Z",
-        "posted": "2023-04-11T16:16:20.733+00:00",
+        "accountNumber": "A21DC313",
+        "posted": "2023-03-21T11:13:39.000+00:00",
         "type": "PI_SECT",
         "amount": 0.01,
         "currency": "EUR",
-        "description": "Incoming payment",
+        "description": "Payment from Aitor Garcia Rey: Enviada desde N26",
+        "originalReference": "Enviada desde N26",
         "providerCode": "BOL",
-        "ledgerBankCode": "BOLIEREG",
-        "payerName": "Jonh ",
+        "ledgerBankCode": "BOLIE",
+        "payerName": "Aitor Garcia Rey",
         "payer": {
-          "name": "Jonh",
+          "name": "Aitor Garcia Rey",
           "identifier": {
             "type": "IBAN",
-            "iban": "GB88MOCK00000001412498"
+            "iban": "ES8731902527103498957662",
+            "bic": "NTSBDEB1XXX"
           }
         },
         "payee": {
-          "name": "Jane",
+          "name": "AGR tests in Devengo Modulr",
           "identifier": {
             "type": "IBAN",
-            "iban": "ES2914653111661392648933"
+            "iban": "IE21MODR99035502154595",
+            "bic": "MODRIE22XXX"
           }
         },
+        "schemeId": "S230800054197732-e44ec0108b074a73b117dbe1fbf44def",
+        "schemeType": "SEPA",
         "clearingRequired": false,
-        "originatedOverseas": false,
-        "details": {},
+        "originatedOverseas": true,
+        "details": {
+          "type": "FFCCTRNS",
+          "payload": {
+            "id": "Edoc",
+            "docs": {
+              "doc": {
+                "header": {
+                  "type": "FFCCTRNS",
+                  "dates": [
+                    {
+                      "date": [
+                        2023,
+                        3,
+                        21,
+                        13,
+                        13,
+                        39
+                      ],
+                      "type": "FormDoc"
+                    }
+                  ],
+                  "docId": "S230800054197732",
+                  "priority": 51,
+                  "reference": [],
+                  "businessArea": "SEPASCT"
+                },
+                "ffcctrns": {
+                  "document": {
+                    "fitoFICstmrCdtTrf": {
+                      "grpHdr": {
+                        "msgId": "S230800054197732",
+                        "creDtTm": [
+                          2023,
+                          3,
+                          21,
+                          13,
+                          13,
+                          39
+                        ],
+                        "nbOfTxs": "1",
+                        "instdAgt": {
+                          "finInstnId": {
+                            "bic": "MODRIE22XXX"
+                          }
+                        },
+                        "sttlmInf": {
+                          "clrSys": {
+                            "prtry": "LITAS_MIG"
+                          },
+                          "sttlmMtd": "CLRG"
+                        },
+                        "intrBkSttlmDt": [
+                          2023,
+                          3,
+                          21
+                        ],
+                        "ttlIntrBkSttlmAmt": {
+                          "ccy": "EUR",
+                          "value": 0.01
+                        }
+                      },
+                      "cdtTrfTxInf": [
+                        {
+                          "cdtr": {
+                            "nm": "AGR tests in Devengo Modulr"
+                          },
+                          "dbtr": {
+                            "nm": "Aitor Garcia Rey"
+                          },
+                          "pmtId": {
+                            "txId": "e44ec0108b074a73b117dbe1fbf44def",
+                            "instrId": "O230801408552580",
+                            "endToEndId": "e44ec0108b074a73b117dbe1fbf44def"
+                          },
+                          "chrgBr": "SLEV",
+                          "rmtInf": {
+                            "ustrd": "Enviada desde N26"
+                          },
+                          "cdtrAgt": {
+                            "finInstnId": {
+                              "bic": "MODRIE22XXX"
+                            }
+                          },
+                          "dbtrAgt": {
+                            "finInstnId": {
+                              "bic": "NTSBDEB1XXX"
+                            }
+                          },
+                          "cdtrAcct": {
+                            "id": {
+                              "iban": "IE21MODR99035502154595"
+                            }
+                          },
+                          "dbtrAcct": {
+                            "id": {
+                              "iban": "ES8731902527103498957662"
+                            }
+                          },
+                          "instgAgt": {
+                            "finInstnId": {
+                              "bic": "MARKDEFF"
+                            }
+                          },
+                          "pmtTpInf": {
+                            "svcLvl": {
+                              "cd": "SEPA"
+                            }
+                          },
+                          "intrBkSttlmAmt": {
+                            "ccy": "EUR",
+                            "value": 0.01
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "type": "FFCCTRNS",
+            "header": {
+              "date": [
+                2023,
+                3,
+                21,
+                13,
+                13,
+                39
+              ],
+              "msgId": "S230800054197732",
+              "sender": "LIABLT2XMSD",
+              "system": "LITAS-MIG",
+              "priority": 51,
+              "receiver": "MODRIE22XXX",
+              "reference": []
+            },
+            "version": "pacs.008.001.02.2021"
+          }
+        },
         "manualRecall": false
       },
-      "reference": "P1200AJ55X"
+      "reference": "P210H5Z0KK"
     }
   ],
   "size": 1,

--- a/spec/fixtures/payments/find/outgoing/responses/success_iban.http
+++ b/spec/fixtures/payments/find/outgoing/responses/success_iban.http
@@ -28,7 +28,7 @@ x-xss-protection: 1; mode=block
         "destinationType": "IBAN",
         "destination": {
           "type": "IBAN",
-          "iban": "ES6015632626303264517956",
+          "iban": "ES8731902527103498957662",
           "name": "Aitor García Rey"
         },
         "currency": "EUR",

--- a/spec/fixtures/payments/list/responses/success.http
+++ b/spec/fixtures/payments/list/responses/success.http
@@ -50,7 +50,7 @@ x-xss-protection: 1; mode=block
         "destinationType":"IBAN",
         "destination": {
           "type":"IBAN",
-          "iban":"ES6015632626303264517956",
+          "iban":"ES8731902527103498957662",
           "name":"Aitor García Rey"
         },
         "currency":"EUR",

--- a/spec/modulr/api/payments_service_spec.rb
+++ b/spec/modulr/api/payments_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
           amount: "0.02",
           destination: {
             type: "IBAN",
-            iban: "ES6015632626303264517956",
+            iban: "ES8731902527103498957662",
             name: "Aitor García Rey",
           },
           reference: "The reference"
@@ -34,7 +34,7 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
           amount: "0.02",
           destination: {
             type: "IBAN",
-            iban: "ES6015632626303264517956",
+            iban: "ES8731902527103498957662",
             name: "Aitor García Rey",
           },
           reference: "The reference",
@@ -117,6 +117,7 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
           expect(fps_payment.details.destination.identifier.type).to eql("SCAN")
           expect(fps_payment.details.destination.identifier.sort_code).to eql("040392")
           expect(fps_payment.details.destination.identifier.account_number).to eql("00631973")
+          expect(fps_payment.end_to_end_id).to eql("Aitor from Wise")
         end
       end
 
@@ -158,7 +159,7 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
           expect(sct_inst_payment.details.payer).to be_a Modulr::Resources::Payments::Counterparty
           expect(sct_inst_payment.details.payer.name).to eql("Aitor Garcia Rey")
           expect(sct_inst_payment.details.payer.identifier.type).to eql("IBAN")
-          expect(sct_inst_payment.details.payer.identifier.iban).to eql("ES6015632626303264517956")
+          expect(sct_inst_payment.details.payer.identifier.iban).to eql("ES8731902527103498957662")
           expect(sct_inst_payment.details.payee).to be_a Modulr::Resources::Payments::Counterparty
           expect(sct_inst_payment.details.payee.name).to eql("AGR tests in Devengo Modulr")
           expect(sct_inst_payment.details.payee.identifier.type).to eql("IBAN")
@@ -166,6 +167,7 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
           expect(sct_inst_payment.details.destination.name).to eql("AGR tests in Devengo Modulr")
           expect(sct_inst_payment.details.destination.identifier.type).to eql("IBAN")
           expect(sct_inst_payment.details.destination.identifier.iban).to eql("IE21MODR99035502154595")
+          expect(sct_inst_payment.end_to_end_id).to eql "NOTPROVIDED"
         end
       end
 
@@ -189,29 +191,30 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
 
         it "returns the payment" do
           expect(sct_regular_payment).to be_a Modulr::Resources::Payments::Payment
-          expect(sct_regular_payment.id).to eql("P1200AJ55X")
+          expect(sct_regular_payment.id).to eql("P210H5Z0KK")
           expect(sct_regular_payment.status).to eql("PROCESSED")
-          expect(sct_regular_payment.created_at).to eql("2023-04-11T16:16:20.020+0000")
-          expect(sct_regular_payment.reference).to eql("P1200AJ55X")
+          expect(sct_regular_payment.created_at).to eql("2023-03-21T11:14:35.035+0000")
+          expect(sct_regular_payment.reference).to eql("P210H5Z0KK")
           expect(sct_regular_payment.details).to be_a Modulr::Resources::Payments::Details::Incoming::General
-          expect(sct_regular_payment.details.created_at).to eql("2023-04-11T16:16:20.733+00:00")
-          expect(sct_regular_payment.details.posted_at).to eql("2023-04-11T16:16:20.733+00:00")
+          expect(sct_regular_payment.details.created_at).to eql("2023-03-21T11:14:35.131+00:00")
+          expect(sct_regular_payment.details.posted_at).to eql("2023-03-21T11:13:39.000+00:00")
           expect(sct_regular_payment.details.type).to eql("PI_SECT")
-          expect(sct_regular_payment.details.description).to eql("Incoming payment")
-          expect(sct_regular_payment.details.original_reference).to be_nil
+          expect(sct_regular_payment.details.description).to eql("Payment from Aitor Garcia Rey: Enviada desde N26")
+          expect(sct_regular_payment.details.original_reference).to eql "Enviada desde N26"
           expect(sct_regular_payment.details.currency).to eql("EUR")
           expect(sct_regular_payment.details.amount).to be 0.01
-          expect(sct_regular_payment.details.account_number).to eql("A1216A1Z")
-          expect(sct_regular_payment.details.scheme_id).to be_nil
-          expect(sct_regular_payment.details.raw_details.keys).to be_empty
+          expect(sct_regular_payment.details.account_number).to eql("A21DC313")
+          expect(sct_regular_payment.details.scheme_id).to eql "S230800054197732-e44ec0108b074a73b117dbe1fbf44def"
+          expect(sct_regular_payment.details.raw_details.keys).not_to be_empty
           expect(sct_regular_payment.details.payer).to be_a Modulr::Resources::Payments::Counterparty
-          expect(sct_regular_payment.details.payer.name).to eql("Jonh")
+          expect(sct_regular_payment.details.payer.name).to eql("Aitor Garcia Rey")
           expect(sct_regular_payment.details.payer.identifier.type).to eql("IBAN")
-          expect(sct_regular_payment.details.payer.identifier.iban).to eql("GB88MOCK00000001412498")
+          expect(sct_regular_payment.details.payer.identifier.iban).to eql("ES8731902527103498957662")
           expect(sct_regular_payment.details.payee).to be_a Modulr::Resources::Payments::Counterparty
-          expect(sct_regular_payment.details.payee.name).to eql("Jane")
+          expect(sct_regular_payment.details.payee.name).to eql("AGR tests in Devengo Modulr")
           expect(sct_regular_payment.details.payee.identifier.type).to eql("IBAN")
-          expect(sct_regular_payment.details.payee.identifier.iban).to eql("ES2914653111661392648933")
+          expect(sct_regular_payment.details.payee.identifier.iban).to eql("IE21MODR99035502154595")
+          expect(sct_regular_payment.end_to_end_id).to eql "e44ec0108b074a73b117dbe1fbf44def"
         end
       end
 
@@ -437,7 +440,7 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
           expect(found_payment.details.destination).to be_a Modulr::Resources::Payments::Destination
           expect(found_payment.details.destination.name).to eql("Aitor García Rey")
           expect(found_payment.details.destination.identifier.type).to eql("IBAN")
-          expect(found_payment.details.destination.identifier.iban).to eql("ES6015632626303264517956")
+          expect(found_payment.details.destination.identifier.iban).to eql("ES8731902527103498957662")
         end
       end
 


### PR DESCRIPTION
This PR adds the `end_to_end_id` to the Payment model.

Modulr response schema changes depending on the schema, so we need to write different code depending on the transaction type. In this PR this field is only filled for Incoming SEPA (Inst/Regular) and Incoming Faster Payments.