### PR TITLE
[DP-1502] Include requested_at field on accounts finder method

### DIFF
--- a/lib/modulr/api/accounts_service.rb
+++ b/lib/modulr/api/accounts_service.rb
@@ -5,7 +5,11 @@ module Modulr
     class AccountsService < Service
       def find(id:)
         response = client.get("/accounts/#{id}")
-        Resources::Accounts::Account.new(response.env[:raw_body], response.body)
+        Resources::Accounts::Account.new(
+          response.env[:raw_body],
+          response.body,
+          { requested_at: response.headers["date"] }
+        )
       end
 
       def create(customer_id:, currency:, product_code:, **opts)

--- a/lib/modulr/resources/accounts/account.rb
+++ b/lib/modulr/resources/accounts/account.rb
@@ -4,7 +4,7 @@ module Modulr
   module Resources
     module Accounts
       class Account < Base
-        attr_reader :identifiers
+        attr_reader :identifiers, :requested_at
 
         STATUS = {
           active: "ACTIVE",
@@ -23,8 +23,9 @@ module Modulr
         map :createdDate, :created_at
         map :directDebit, :direct_debit
 
-        def initialize(raw_response, attributes = {})
+        def initialize(raw_response, attributes = {}, opts = { requested_at: nil })
           super(raw_response, attributes)
+          @requested_at = opts[:requested_at]
           @identifiers = Accounts::Identifiers.new(nil, attributes[:identifiers])
         end
       end

--- a/spec/fixtures/accounts/find/responses/success.http
+++ b/spec/fixtures/accounts/find/responses/success.http
@@ -15,5 +15,6 @@ x-ratelimit-limit: 4000000
 x-ratelimit-remaining: 3999987
 x-ratelimit-reset: 1674464655
 x-xss-protection: 1; mode=block
+date: Wed, 06 Sep 2023 10:30:42 GMT
 
 {"id":"A21C64X7","name":"Devengo","balance":"0.00","availableBalance":"0.00","currency":"EUR","status":"ACTIVE","identifiers":[{"type":"IBAN","iban":"IE20MODR99035502290414","bic":"MODRIE22XXX","providerExtraInfo":{"sortCode":"990356","accountNumber":"02290414"}}],"customerId":"C0000001","customerName":"Devengo","externalReference":"A new account in EUR","accessGroups":[],"createdDate":"2023-01-18T11:20:00.897+0000","directDebit":false}

--- a/spec/modulr/api/accounts_service_spec.rb
+++ b/spec/modulr/api/accounts_service_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Modulr::API::AccountsService, :unit, type: :client do
       }
 
       it "returns created account" do
+        expect(created_account.requested_at).to be_nil
         expect(created_account).to be_a Modulr::Resources::Accounts::Account
         expect(created_account.customer_id).to eql("C0000001")
         expect(created_account.external_reference).to eql("A new account in EUR")
@@ -100,6 +101,7 @@ RSpec.describe Modulr::API::AccountsService, :unit, type: :client do
       }
 
       it "returns the account" do
+        expect(found_account.requested_at).to eql("Wed, 06 Sep 2023 10:30:42 GMT")
         expect(found_account).to be_a Modulr::Resources::Accounts::Account
         expect(found_account.customer_id).to eql("C0000001")
         expect(found_account.external_reference).to eql("A new account in EUR")


### PR DESCRIPTION
It is pleasant but also necessary to know the exact moment we require modulr balance since modulr does not return any info about it in payloads.

Modulr returns balance data on `/accounts` endpoint and inside this payload we can not be sure about the time this balance is effective in modulr side. That is why this PR includes a `requested_at` account field that extract response date and include it into account object found.

```ruby
Modulr::Resources::Accounts::Account.new.requested_at == "Wed, 06 Sep 2023 10:30:42 GMT"
```

[DP-1502](https://devengers.atlassian.net/browse/DP-1502)

[DP-1502]: https://devengers.atlassian.net/browse/DP-1502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ