### PR TITLE
Allow items accessor from resources collection

### DIFF
--- a/lib/modulr/resources/base_collection.rb
+++ b/lib/modulr/resources/base_collection.rb
@@ -3,7 +3,7 @@
 module Modulr
   module Resources
     class BaseCollection
-      attr_reader :raw_response
+      attr_reader :raw_response, :items
 
       include Enumerable
 


### PR DESCRIPTION
[DP-1504](https://devengers.atlassian.net/browse/DP-1504)

Sometimes we need to iterate over items and it is quite dificult doing through collection object which does not implement many of array methods provided by ruby language. In that case we allow access items' collection as pure array object which allow us to use any array helper method instead.

[DP-1504]: https://devengers.atlassian.net/browse/DP-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ