### PR TITLE
Refactor the way we wrapped connection errors.

### DIFF
--- a/lib/modulr/api/payments_service.rb
+++ b/lib/modulr/api/payments_service.rb
@@ -6,7 +6,7 @@ module Modulr
       def find(id:)
         response = client.get("/payments", { id: id })
         payment_attributes = response.body[:content]&.first
-        raise NotFoundError, "Payment #{id} not found" unless payment_attributes
+        raise ClientError, "Payment #{id} not found" unless payment_attributes
 
         Resources::Payments::Payment.new(response.env[:raw_body], payment_attributes)
       end

--- a/lib/modulr/client.rb
+++ b/lib/modulr/client.rb
@@ -97,19 +97,13 @@ module Modulr
     end
 
     def handle_request_error(error)
-      response = error.response
       case error
       when Faraday::ClientError
-        case response[:status]
-        when 403
-          raise ForbiddenError, response
-        when 404
-          raise NotFoundError, response
-        else
-          raise RequestError, response
-        end
+        raise ClientError, error
+      when Faraday::ServerError
+        raise ServerError, error
       else
-        raise Error, response
+        raise Error, error
       end
     end
 

--- a/lib/modulr/error.rb
+++ b/lib/modulr/error.rb
@@ -6,7 +6,7 @@ module Modulr
 
     def initialize(error)
       @wrapped_error = error
-      @response = @wrapped_error.response
+      @response = @wrapped_error.response if @wrapped_error.respond_to?(:response)
       @status = structured_response[:status]
       super(error_message)
     end

--- a/spec/modulr/api/accounts_service_spec.rb
+++ b/spec/modulr/api/accounts_service_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Modulr::API::AccountsService, :unit, type: :client do
       end
 
       it "raise the correct error" do
-        expect { accounts.create(**params) }.to raise_error Modulr::RequestError
+        expect { accounts.create(**params) }.to raise_error Modulr::ClientError
       end
     end
 
@@ -78,7 +78,7 @@ RSpec.describe Modulr::API::AccountsService, :unit, type: :client do
       end
 
       it "raise the correct error" do
-        expect { accounts.create(**params) }.to raise_error Modulr::RequestError
+        expect { accounts.create(**params) }.to raise_error Modulr::ClientError
       end
     end
   end
@@ -118,7 +118,7 @@ RSpec.describe Modulr::API::AccountsService, :unit, type: :client do
       end
 
       it "raise the correct error" do
-        expect { accounts.find(id: "AAA") }.to raise_error Modulr::RequestError
+        expect { accounts.find(id: "AAA") }.to raise_error Modulr::ClientError
       end
     end
 
@@ -130,7 +130,7 @@ RSpec.describe Modulr::API::AccountsService, :unit, type: :client do
       end
 
       it "raise the correct error" do
-        expect { accounts.find(id: "A99C99X9") }.to raise_error Modulr::NotFoundError
+        expect { accounts.find(id: "A99C99X9") }.to raise_error Modulr::ClientError
       end
     end
   end

--- a/spec/modulr/api/customers_service_spec.rb
+++ b/spec/modulr/api/customers_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Modulr::API::CustomersService, :unit, type: :client do
       end
 
       it "raise the correct error" do
-        expect { customers.find(id: "CCC") }.to raise_error Modulr::RequestError
+        expect { customers.find(id: "CCC") }.to raise_error Modulr::ClientError
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Modulr::API::CustomersService, :unit, type: :client do
       end
 
       it "raise the correct error" do
-        expect { customers.find(id: "C9999C99") }.to raise_error Modulr::NotFoundError
+        expect { customers.find(id: "C9999C99") }.to raise_error Modulr::ClientError
       end
     end
   end
@@ -248,7 +248,7 @@ RSpec.describe Modulr::API::CustomersService, :unit, type: :client do
       end
 
       it "raise the correct error" do
-        expect { customers.create(**params) }.to raise_error Modulr::RequestError
+        expect { customers.create(**params) }.to raise_error Modulr::ClientError
       end
     end
 
@@ -267,7 +267,7 @@ RSpec.describe Modulr::API::CustomersService, :unit, type: :client do
       end
 
       it "raise the correct error" do
-        expect { customers.create(**params) }.to raise_error Modulr::RequestError
+        expect { customers.create(**params) }.to raise_error Modulr::ClientError
       end
     end
   end

--- a/spec/modulr/api/notifications_service_spec.rb
+++ b/spec/modulr/api/notifications_service_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# frozen_string_literal: true
-
 RSpec.describe Modulr::API::NotificationsService, :unit, type: :client do
   subject(:notifications) { described_class.new(initialize_client) }
 
@@ -64,9 +62,8 @@ RSpec.describe Modulr::API::NotificationsService, :unit, type: :client do
 
       it "raise the correct error" do
         expect { notifications.create(**params) }.to(raise_error do |exception|
-          expect(exception).to be_a(Modulr::RequestError)
-          expect(exception.errors).not_to be_empty
-          expect(exception.errors.select { |error| error[:field] == "config.secret" }).not_to be_empty
+          expect(exception).to be_a(Modulr::ClientError)
+          expect(exception.status).to be(400)
         end)
       end
     end
@@ -90,9 +87,8 @@ RSpec.describe Modulr::API::NotificationsService, :unit, type: :client do
 
       it "raise the correct error" do
         expect { notifications.create(**params) }.to(raise_error do |exception|
-          expect(exception).to be_a(Modulr::RequestError)
-          expect(exception.errors).not_to be_empty
-          expect(exception.errors.select { |error| error[:field] == "type" }).not_to be_empty
+          expect(exception).to be_a(Modulr::ClientError)
+          expect(exception.status).to be(400)
         end)
       end
     end

--- a/spec/modulr/api/payments_service_spec.rb
+++ b/spec/modulr/api/payments_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
       end
 
       it "raise the correct error" do
-        expect { payments.find(id: "P99C99X9") }.to raise_error Modulr::NotFoundError
+        expect { payments.find(id: "P99C99X9") }.to raise_error Modulr::ClientError
       end
     end
 
@@ -631,9 +631,8 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
 
       it "raise the correct error" do
         expect { payments.list(from: Date.today - 300) }.to(raise_error do |exception|
-          expect(exception).to be_a(Modulr::RequestError)
-          expect(exception.errors).not_to be_empty
-          expect(exception.errors.select { |error| error[:field] == "fromCreatedDate" }).not_to be_empty
+          expect(exception).to be_a(Modulr::ClientError)
+          expect(exception.status).to be(400)
         end)
       end
     end

--- a/spec/modulr/api/transactions_service_spec.rb
+++ b/spec/modulr/api/transactions_service_spec.rb
@@ -55,8 +55,7 @@ RSpec.describe Modulr::API::TransactionsService, :unit, type: :client do
       it "raise the correct error" do
         expect { transactions.list(account_id: "A0000001", min_amount: -100) }.to(raise_error do |exception|
           expect(exception).to be_a(Modulr::ClientError)
-          expect(exception.errors).not_to be_empty
-          expect(exception.errors.select { |error| error[:field] == "minAmount" }).not_to be_empty
+          expect(exception.status).to be(400)
         end)
       end
     end

--- a/spec/modulr/api/transactions_service_spec.rb
+++ b/spec/modulr/api/transactions_service_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Modulr::API::TransactionsService, :unit, type: :client do
 
       it "raise the correct error" do
         expect { transactions.list(account_id: "A0000001", min_amount: -100) }.to(raise_error do |exception|
-          expect(exception).to be_a(Modulr::RequestError)
+          expect(exception).to be_a(Modulr::ClientError)
           expect(exception.errors).not_to be_empty
           expect(exception.errors.select { |error| error[:field] == "minAmount" }).not_to be_empty
         end)


### PR DESCRIPTION
Until now, we have been wrapping the errors produced by Modulr irregularly, with some specific cases (like a 403) getting their own error/exception and others (like a 504) getting a generic one. 

This PR proposes a few changes in this approach:
* A new, simplified taxonomy of errors:
  * All 4xx errors get wrapped under a `Modulr::ClientError`
  * All 5xx errors get wrapped under a `Modulr::ServerError`   
  * Anything else (parsing, connection errors) gets wrapped under a `Modulr::Error`
* The original error raised by the HTTP library is included in the wrapping exception and accessible by `error#wrapped_error`
* The `status` and `response` returned by Modulr are, when available, accessible by `error#status` and `error#response`
 

To test all the possible cases, this PR has been tested using a simple Sinatra app that easily replicates different network/connection conditions like:

```rb
require 'sinatra'

before do
  content_type :json
end

%i[get post].each do |method|
  send method, '/timeout*' do
    sleep(100)
  end
end

%i[get post].each do |method|
  send method, '/504*' do
    status 504
  end
end
```

Then, a simplification of what we use in the production has been used:

```rb
begin
  Modulr::Client.new.accounts.find(id: "WHATEVER")
rescue StandardError => e
  puts e.inspect
end
```


These are some examples of what the library will return.

#### Modulr servers are down or unresponsive

```rb
#<Modulr::ServerError: Net::ReadTimeout with #<Socket:(closed)>>
```

#### Modulr servers SSL misconfiguration

```rb
#<Modulr::Error: SSL_connect returned=1 errno=0 peeraddr=127.0.0.1:4567 state=error: wrong version number>
```

#### Modulr servers respond non-JSON answers

```rb
#<Modulr::Error: Status: 200 - Response: 'fwefe: 3r, r3' (Faraday::ParsingError: 859: unexpected token at 'fwefe: 3r, r3')>
```

#### Modulr servers respond with a 401

```rb
#<Modulr::ClientError: Status: 401 - Response: '' (Faraday::UnauthorizedError: the server responded with status 401)>
```

#### Modulr servers respond with a 400

```rb
#<Modulr::ClientError: Status: 400 - Response: '[{:field=>"paymentOutMessage", :code=>"BUSINESSRULE", :message=>"Destination beneficiary not found or cannot be created. Invalid IBAN"}]' (Faraday::BadRequestError: the server responded with status 400)>
```

#### Modulr servers crash 

```rb
#<Modulr::ServerError: Status: 500 - Response: '' (Faraday::ServerError: the server responded with status 500)>
```

#### Modulr servers respond with a timeout

```rb
#<Modulr::ServerError: Status: 504 - Response: '' (Faraday::ServerError: the server responded with status 504)>
```