### PR TITLE
Fix double slashes in notifications url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+.DS_Store
 
 # rspec failure tracking
 .rspec_status
@@ -16,3 +17,4 @@
 .idea
 *.iml
 out
+.vscode/

--- a/lib/modulr/api/notifications_service.rb
+++ b/lib/modulr/api/notifications_service.rb
@@ -4,14 +4,16 @@ module Modulr
   module API
     class NotificationsService < Service
       def find(id:, **opts)
-        response = client.get("#{base_notification_url(opts)}/notifications/#{id}")
+        url = File.join(base_notification_url(opts), "notifications", id.to_s)
+        response = client.get(url)
         attributes = response.body
 
         Resources::Notifications::Notification.new(response, attributes)
       end
 
       def list(**opts)
-        response = client.get("#{base_notification_url(opts)}/notifications")
+        url = File.join(base_notification_url!(opts), "notifications")
+        response = client.get(url)
         attributes_collection = response.body
 
         Resources::Notifications::Collection.new(response, attributes_collection)
@@ -24,7 +26,8 @@ module Modulr
           destinations: destinations,
           config: config,
         }
-        response = client.post("#{base_notification_url(opts)}/notifications", payload)
+        url = File.join(base_notification_url!(opts), "notifications")
+        response = client.post(url, payload)
         attributes = response.body
 
         Resources::Notifications::Notification.new(response, attributes)
@@ -36,7 +39,8 @@ module Modulr
           destinations: destinations,
           config: config,
         }
-        response = client.put("#{base_notification_url(opts)}/notifications/#{id}", payload)
+        url = File.join(base_notification_url!(opts), "notifications", id.to_s)
+        response = client.put(url, payload)
         attributes = response.body
 
         Resources::Notifications::Notification.new(response, attributes)


### PR DESCRIPTION
This PR ensures that all URLs in the NotificationsService are built safely using File.join, which prevents accidental double slashes when optional parameters are missing (e.g., a missing customer_id).

Previously, if customer_id was missing or nil, a URL like /customers//notifications/... could be generated, leading to a 301 redirect from Modulr’s API and causing write requests (like PUT) to fail:

```bash
I, [2025-05-22T08:01:07.634055 #2]  INFO -- request: PUT https://api.modulrfinance.com/api/customers//notifications/***
I, [2025-05-22T08:01:07.634114 #2]  INFO -- request: User-Agent: "Faraday v1.10.4"
Content-Type: "application/json"
Authorization: "Signature keyId=\"***\""
Date: "Thu, 22 May 2025 08:01:07 GMT"
X-mod-nonce: "***"
I, [2025-05-22T08:01:07.634147 #2]  INFO -- request: {"status":"ACTIVE","destinations":["https://api.devengo.com/banking/webhooks/modulr/com_***/payment_compliance"],"config":{"retry":true,"secret":"***","hmacAlgorithm":"hmac-sha512"}}
I, [2025-05-22T08:01:07.663691 #2]  INFO -- response: Status 301
I, [2025-05-22T08:01:07.663754 #2]  INFO -- response: date: "Thu, 22 May 2025 08:01:07 GMT"
content-length: "0"
connection: "keep-alive"
location: "/api/customers/notifications/***"
```