### PR TITLE
Add idempotency requests

### DIFF
--- a/lib/modulr/api/accounts_service.rb
+++ b/lib/modulr/api/accounts_service.rb
@@ -27,14 +27,14 @@ module Modulr
         }
         payload[:externalReference] = opts[:external_reference] if opts[:external_reference]
 
-        response = client.post("/customers/#{customer_id}/accounts", payload, idempotency_headers(opts))
+        response = client.post("/customers/#{customer_id}/accounts", payload, opts)
         attributes = response.body
 
         Resources::Accounts::Account.new(response, attributes)
       end
 
       def close(account_id:, **opts)
-        client.post("/accounts/#{account_id}/close", nil, idempotency_headers(opts))
+        client.post("/accounts/#{account_id}/close", nil, opts)
 
         nil
       end

--- a/lib/modulr/api/accounts_service.rb
+++ b/lib/modulr/api/accounts_service.rb
@@ -33,8 +33,8 @@ module Modulr
         Resources::Accounts::Account.new(response, attributes)
       end
 
-      def close(account_id:)
-        client.post("/accounts/#{account_id}/close")
+      def close(account_id:, **opts)
+        client.post("/accounts/#{account_id}/close", nil, idempotency_headers(opts))
 
         nil
       end

--- a/lib/modulr/api/accounts_service.rb
+++ b/lib/modulr/api/accounts_service.rb
@@ -27,7 +27,7 @@ module Modulr
         }
         payload[:externalReference] = opts[:external_reference] if opts[:external_reference]
 
-        response = client.post("/customers/#{customer_id}/accounts", payload)
+        response = client.post("/customers/#{customer_id}/accounts", payload, idempotency_headers(opts))
         attributes = response.body
 
         Resources::Accounts::Account.new(response, attributes)

--- a/lib/modulr/api/customers_service.rb
+++ b/lib/modulr/api/customers_service.rb
@@ -32,7 +32,7 @@ module Modulr
         payload[:customerTrust] = opts[:customer_trust] if opts[:customer_trust]
         payload[:taxProfile] = opts[:tax_profile] if opts[:tax_profile]
 
-        response = client.post("/customers", payload, idempotency_headers(opts))
+        response = client.post("/customers", payload, opts)
         attributes = response.body
 
         Resources::Customers::Customer.new(response, attributes)

--- a/lib/modulr/api/customers_service.rb
+++ b/lib/modulr/api/customers_service.rb
@@ -32,7 +32,7 @@ module Modulr
         payload[:customerTrust] = opts[:customer_trust] if opts[:customer_trust]
         payload[:taxProfile] = opts[:tax_profile] if opts[:tax_profile]
 
-        response = client.post("/customers", payload)
+        response = client.post("/customers", payload, idempotency_headers(opts))
         attributes = response.body
 
         Resources::Customers::Customer.new(response, attributes)

--- a/lib/modulr/api/notifications_service.rb
+++ b/lib/modulr/api/notifications_service.rb
@@ -24,7 +24,7 @@ module Modulr
           destinations: destinations,
           config: config,
         }
-        response = client.post("#{base_notification_url(opts)}/notifications", payload)
+        response = client.post("#{base_notification_url(opts)}/notifications", payload, idempotency_headers(opts))
         attributes = response.body
 
         Resources::Notifications::Notification.new(response, attributes)
@@ -36,7 +36,7 @@ module Modulr
           destinations: destinations,
           config: config,
         }
-        response = client.put("#{base_notification_url(opts)}/notifications/#{id}", payload)
+        response = client.put("#{base_notification_url(opts)}/notifications/#{id}", payload, idempotency_headers(opts))
         attributes = response.body
 
         Resources::Notifications::Notification.new(response, attributes)

--- a/lib/modulr/api/notifications_service.rb
+++ b/lib/modulr/api/notifications_service.rb
@@ -24,7 +24,7 @@ module Modulr
           destinations: destinations,
           config: config,
         }
-        response = client.post("#{base_notification_url(opts)}/notifications", payload, idempotency_headers(opts))
+        response = client.post("#{base_notification_url(opts)}/notifications", payload, opts)
         attributes = response.body
 
         Resources::Notifications::Notification.new(response, attributes)
@@ -36,7 +36,7 @@ module Modulr
           destinations: destinations,
           config: config,
         }
-        response = client.put("#{base_notification_url(opts)}/notifications/#{id}", payload, idempotency_headers(opts))
+        response = client.put("#{base_notification_url(opts)}/notifications/#{id}", payload, opts)
         attributes = response.body
 
         Resources::Notifications::Notification.new(response, attributes)

--- a/lib/modulr/api/payments_service.rb
+++ b/lib/modulr/api/payments_service.rb
@@ -33,7 +33,7 @@ module Modulr
         payload[:endToEndReference] = opts[:e2e_reference] if opts[:e2e_reference]
         payload[:permittedScheme] = opts[:permitted_scheme] if opts[:permitted_scheme]
 
-        response = client.post("/payments", payload, idempotency_headers(opts))
+        response = client.post("/payments", payload, opts)
         attributes = response.body
 
         Resources::Payments::Payment.new(response, attributes, { network_scheme: false })

--- a/lib/modulr/api/payments_service.rb
+++ b/lib/modulr/api/payments_service.rb
@@ -33,7 +33,7 @@ module Modulr
         payload[:endToEndReference] = opts[:e2e_reference] if opts[:e2e_reference]
         payload[:permittedScheme] = opts[:permitted_scheme] if opts[:permitted_scheme]
 
-        response = client.post("/payments", payload)
+        response = client.post("/payments", payload, idempotency_headers(opts))
         attributes = response.body
 
         Resources::Payments::Payment.new(response, attributes, { network_scheme: false })

--- a/lib/modulr/api/service.rb
+++ b/lib/modulr/api/service.rb
@@ -9,6 +9,12 @@ module Modulr
         @client = client
       end
 
+      def idempotency_headers(options)
+        headers = {}
+        headers[:idempotency_key] = options[:idempotency_key] if options[:idempotency_key]
+        headers
+      end
+
       def format_datetime(datetime)
         datetime.strftime("%Y-%m-%dT%H:%M:%S%z")
       end

--- a/lib/modulr/auth/signature.rb
+++ b/lib/modulr/auth/signature.rb
@@ -23,7 +23,8 @@ module Modulr
         ].join(",")
       end
 
-      def self.calculate(apikey:, apisecret:, nonce: SecureRandom.base64(30), timestamp: DateTime.now.httpdate)
+      def self.calculate(apikey:, apisecret:, nonce: nil, timestamp: DateTime.now.httpdate)
+        nonce ||= SecureRandom.base64(30)
         signature_string = "date: #{timestamp}\nx-mod-nonce: #{nonce}"
         digest = OpenSSL::HMAC.digest(
           "SHA512",

--- a/lib/modulr/client.rb
+++ b/lib/modulr/client.rb
@@ -46,19 +46,15 @@ module Modulr
     end
 
     def get(path, options = {})
-      execute :get, path, nil, options
+      request :get, path, nil, options
     end
 
     def post(path, data = nil, options = {})
-      execute :post, path, data, options
+      request :post, path, data, options
     end
 
     def put(path, data = nil, options = {})
-      execute :put, path, data, options
-    end
-
-    def execute(method, path, data = nil, options = {})
-      request(method, path, data, options)
+      request :put, path, data, options
     end
 
     def self.idempotency_nonce(idempotency_key)
@@ -79,6 +75,8 @@ module Modulr
         handle_request_error(e)
       end
     end
+
+    alias execute request
 
     def request_options(method, _path, data, options)
       default_options.tap do |defaults|
@@ -109,7 +107,7 @@ module Modulr
     def idempotency_headers(options, idempotency_key)
       return unless idempotency_key
 
-      nonce = generate_nonce(idempotency_key)
+      nonce = self.class.idempotency_nonce(idempotency_key)
       options[:"x-mod-nonce"] = nonce
       options[:"x-mod-retry"] = "true" if nonce && !nonce.empty?
     end
@@ -118,11 +116,7 @@ module Modulr
       return unless options
       return unless method == :get
 
-      if options.is_a?(Hash)
-        request.params.update(options.reject { |k, _| k == :idempotency_key })
-      else
-        request.params.update(options)
-      end
+      request.params.update(options.reject { |k, _| k == :idempotency_key })
     end
 
     def handle_request_error(error)
@@ -147,10 +141,6 @@ module Modulr
           content_type: "application/json",
         },
       }
-    end
-
-    private def generate_nonce(idempotency_key)
-      self.class.idempotency_nonce(idempotency_key)
     end
   end
 end

--- a/lib/modulr/client.rb
+++ b/lib/modulr/client.rb
@@ -80,8 +80,8 @@ module Modulr
 
     def request_options(method, _path, data, options)
       default_options.tap do |defaults|
-        idempotency_headers(defaults[:headers], options&.dig(:idempotency_key)) unless method == :get
         add_auth_options!(defaults)
+        add_idempotency_headers!(defaults[:headers], method, options) if options
         defaults[:body] = JSON.dump(data) if data
       end
     end
@@ -104,12 +104,15 @@ module Modulr
       options[:headers][:"x-mod-nonce"] ||= signature.nonce
     end
 
-    def idempotency_headers(options, idempotency_key)
+    private def add_idempotency_headers!(headers, method, options)
+      return if method == :get
+
+      idempotency_key = options.delete(:idempotency_key)
       return unless idempotency_key
 
       nonce = self.class.idempotency_nonce(idempotency_key)
-      options[:"x-mod-nonce"] = nonce
-      options[:"x-mod-retry"] = "true" if nonce && !nonce.empty?
+      headers[:"x-mod-nonce"] = nonce
+      headers[:"x-mod-retry"] = "true" if nonce && !nonce.empty?
     end
 
     private def merge_query_params(request, method, options)

--- a/lib/modulr/client.rb
+++ b/lib/modulr/client.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "base64"
+require "openssl"
 require "faraday"
 require "faraday_middleware"
 require "json"
@@ -59,21 +61,28 @@ module Modulr
       request(method, path, data, options)
     end
 
+    def self.idempotency_nonce(idempotency_key)
+      digest = OpenSSL::Digest.new("SHA256")
+      hash = OpenSSL::HMAC.digest(digest, ENV["MODULR_APIKEY"], idempotency_key)
+      Base64.urlsafe_encode64(hash)
+    end
+
     def request(method, path, data = nil, options = {})
       request_options = request_options(method, path, data, options)
       uri = "#{base_url}#{path}"
 
       begin
         connection.run_request(method, uri, request_options[:body], request_options[:headers]) do |request|
-          request.params.update(options) if options
+          merge_query_params(request, method, options)
         end
       rescue StandardError => e
         handle_request_error(e)
       end
     end
 
-    def request_options(_method, _path, data, _options)
+    def request_options(_method, _path, data, options)
       default_options.tap do |defaults|
+        idempotency_headers(defaults[:headers], options&.dig(:idempotency_key))
         add_auth_options!(defaults)
         defaults[:body] = JSON.dump(data) if data
       end
@@ -91,9 +100,25 @@ module Modulr
 
     def auth_options(options)
       signature = Auth::Signature.calculate(apikey: @apikey, apisecret: @apisecret)
+
       options[:headers][:authorization] = signature.authorization
       options[:headers][:date] = signature.timestamp
-      options[:headers][:"x-mod-nonce"] = signature.nonce
+      options[:headers][:"x-mod-nonce"] ||= signature.nonce
+    end
+
+    def idempotency_headers(options, idempotency_key)
+      return unless idempotency_key
+
+      nonce = generate_nonce(idempotency_key)
+      options[:"x-mod-nonce"] = nonce
+      options[:"x-mod-retry"] = "true" if nonce && !nonce.empty?
+    end
+
+    private def merge_query_params(request, method, options)
+      return unless options
+      return unless method == :get
+
+      request.params.update(options)
     end
 
     def handle_request_error(error)
@@ -118,6 +143,10 @@ module Modulr
           content_type: "application/json",
         },
       }
+    end
+
+    private def generate_nonce(idempotency_key)
+      self.class.idempotency_nonce(idempotency_key)
     end
   end
 end

--- a/lib/modulr/client.rb
+++ b/lib/modulr/client.rb
@@ -80,9 +80,9 @@ module Modulr
       end
     end
 
-    def request_options(_method, _path, data, options)
+    def request_options(method, _path, data, options)
       default_options.tap do |defaults|
-        idempotency_headers(defaults[:headers], options&.dig(:idempotency_key))
+        idempotency_headers(defaults[:headers], options&.dig(:idempotency_key)) unless method == :get
         add_auth_options!(defaults)
         defaults[:body] = JSON.dump(data) if data
       end
@@ -118,7 +118,11 @@ module Modulr
       return unless options
       return unless method == :get
 
-      request.params.update(options)
+      if options.is_a?(Hash)
+        request.params.update(options.reject { |k, _| k == :idempotency_key })
+      else
+        request.params.update(options)
+      end
     end
 
     def handle_request_error(error)

--- a/spec/modulr/api/accounts_service_spec.rb
+++ b/spec/modulr/api/accounts_service_spec.rb
@@ -40,6 +40,53 @@ RSpec.describe Modulr::API::AccountsService, :unit, type: :client do
       end
     end
 
+    context "when idempotency_key is provided" do
+      before do
+        stub_request(:post, %r{/customers/C0000001/accounts}).to_return(
+          read_http_response_fixture("accounts/create", "success")
+        )
+        stub_modulr_apikey_env_for_idempotency
+      end
+
+      let(:idempotency_key) { "account-create-idempotency-xyz" }
+
+      let!(:created_account_with_idempotency) do
+        accounts.create(
+          customer_id: "C0000001",
+          currency: "EUR",
+          product_code: "productCode",
+          external_reference: "A new account in EUR",
+          idempotency_key: idempotency_key,
+        )
+      end
+
+      it "builds correct request with idempotency headers" do
+        expect(WebMock).to have_requested(:post, %r{/customers/C0000001/accounts}).with(
+          headers: modulr_idempotency_request_headers(idempotency_key),
+          body: {
+            currency: "EUR",
+            productCode: "productCode",
+            externalReference: "A new account in EUR",
+          },
+        )
+      end
+
+      it "does not append idempotency_key to the query string" do
+        expect(WebMock).to have_requested(:post, %r{/customers/C0000001/accounts}).with { |req|
+          modulr_request_query_excludes_idempotency_key?(req)
+        }
+      end
+
+      it "returns created account" do
+        expect(created_account_with_idempotency.requested_at).to be_nil
+        expect(created_account_with_idempotency).to be_a Modulr::Resources::Accounts::Account
+        expect(created_account_with_idempotency.customer_id).to eql("C0000001")
+        expect(created_account_with_idempotency.external_reference).to eql("A new account in EUR")
+        expect(created_account_with_idempotency.balance).to eql("0.00")
+        expect(created_account_with_idempotency.available_balance).to be_nil
+      end
+    end
+
     context "when the currency is invalid" do
       before do
         stub_request(:post, %r{/customers/C0000001/accounts}).to_return(

--- a/spec/modulr/api/accounts_service_spec.rb
+++ b/spec/modulr/api/accounts_service_spec.rb
@@ -185,23 +185,58 @@ RSpec.describe Modulr::API::AccountsService, :unit, type: :client do
   end
 
   describe "close account" do
-    before do
-      stub_request(:post, %r{/accounts/A121AHGZ/close}).to_return(
-        read_http_response_fixture("accounts/close", "success")
-      )
+    context "when idempotency_key is not provided" do
+      before do
+        stub_request(:post, %r{/accounts/A121AHGZ/close}).to_return(
+          read_http_response_fixture("accounts/close", "success")
+        )
+      end
+
+      let!(:method_response) do
+        accounts.close(account_id: "A121AHGZ")
+      end
+
+      it_behaves_like "builds correct request", {
+        method: :post,
+        path: %r{/accounts/A121AHGZ/close},
+      }
+
+      it "returns nil" do
+        expect(method_response).to be_nil
+      end
     end
 
-    let!(:method_response) do
-      accounts.close(account_id: "A121AHGZ")
-    end
+    context "when idempotency_key is provided" do
+      before do
+        stub_request(:post, %r{/accounts/A121AHGZ/close}).to_return(
+          read_http_response_fixture("accounts/close", "success")
+        )
+        stub_modulr_apikey_env_for_idempotency
+      end
 
-    it_behaves_like "builds correct request", {
-      method: :post,
-      path: %r{/accounts/A121AHGZ/close},
-    }
+      let(:idempotency_key) { "account-close-idempotency-xyz" }
 
-    it "returns nil" do
-      expect(method_response).to be_nil
+      let!(:close_with_idempotency) do
+        accounts.close(account_id: "A121AHGZ", idempotency_key: idempotency_key)
+      end
+
+      it "builds correct request with idempotency headers" do
+        expect(WebMock).to have_requested(:post, %r{/accounts/A121AHGZ/close}).with(
+          headers: modulr_idempotency_request_headers(idempotency_key)
+        )
+      end
+
+      it "does not append idempotency_key to the query string" do
+        expect(WebMock).to(
+          have_requested(:post, %r{/accounts/A121AHGZ/close}).with do |req|
+            modulr_request_query_excludes_idempotency_key?(req)
+          end
+        )
+      end
+
+      it "returns nil" do
+        expect(close_with_idempotency).to be_nil
+      end
     end
   end
 end

--- a/spec/modulr/api/accounts_service_spec.rb
+++ b/spec/modulr/api/accounts_service_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Modulr::API::AccountsService, :unit, type: :client do
           currency: "EUR",
           product_code: "productCode",
           external_reference: "A new account in EUR",
-          idempotency_key: idempotency_key,
+          idempotency_key: idempotency_key
         )
       end
 
@@ -67,14 +67,16 @@ RSpec.describe Modulr::API::AccountsService, :unit, type: :client do
             currency: "EUR",
             productCode: "productCode",
             externalReference: "A new account in EUR",
-          },
+          }
         )
       end
 
       it "does not append idempotency_key to the query string" do
-        expect(WebMock).to have_requested(:post, %r{/customers/C0000001/accounts}).with { |req|
-          modulr_request_query_excludes_idempotency_key?(req)
-        }
+        expect(WebMock).to(
+          have_requested(:post, %r{/customers/C0000001/accounts}).with do |req|
+            modulr_request_query_excludes_idempotency_key?(req)
+          end
+        )
       end
 
       it "returns created account" do

--- a/spec/modulr/api/customers_service_spec.rb
+++ b/spec/modulr/api/customers_service_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe Modulr::API::CustomersService, :unit, type: :client do
           tax_profile: {
             taxIdentifier: "string",
           },
-          idempotency_key: idempotency_key,
+          idempotency_key: idempotency_key
         )
       end
 
@@ -403,14 +403,16 @@ RSpec.describe Modulr::API::CustomersService, :unit, type: :client do
             taxProfile: {
               taxIdentifier: "string",
             },
-          },
+          }
         )
       end
 
       it "does not append idempotency_key to the query string" do
-        expect(WebMock).to have_requested(:post, %r{/customers}).with { |req|
-          modulr_request_query_excludes_idempotency_key?(req)
-        }
+        expect(WebMock).to(
+          have_requested(:post, %r{/customers}).with do |req|
+            modulr_request_query_excludes_idempotency_key?(req)
+          end
+        )
       end
 
       it "returns created customer" do

--- a/spec/modulr/api/customers_service_spec.rb
+++ b/spec/modulr/api/customers_service_spec.rb
@@ -233,6 +233,192 @@ RSpec.describe Modulr::API::CustomersService, :unit, type: :client do
       end
     end
 
+    context "when idempotency_key is provided" do
+      before do
+        stub_request(:post, %r{/customers}).to_return(
+          read_http_response_fixture("customers/create", "success")
+        )
+        stub_modulr_apikey_env_for_idempotency
+      end
+
+      let(:idempotency_key) { "customer-create-idempotency-xyz" }
+
+      let!(:created_customer_with_idempotency) do
+        customers.create(
+          type: "LLC",
+          legal_entity: "GB",
+          external_reference: "My new customer",
+          name: "string",
+          company_reg_number: "2018123987165432",
+          registered_address: {
+            addressLine1: "string",
+            addressLine2: "string",
+            postTown: "string",
+            postCode: "string",
+            country: "GB",
+            countrySubDivision: "string",
+          },
+          trading_address: {
+            addressLine1: "string",
+            addressLine2: "string",
+            postTown: "string",
+            postCode: "string",
+            country: "GB",
+            countrySubDivision: "string",
+          },
+          industry_code: "string",
+          tcs_version: 0,
+          expected_monthly_spend: 0,
+          associates: [
+            {
+              type: "DIRECTOR",
+              firstName: "string",
+              middleName: "string",
+              lastName: "string",
+              dateOfBirth: "string",
+              ownership: 0,
+              homeAddress: {
+                addressLine1: "string",
+                addressLine2: "string",
+                postTown: "string",
+                postCode: "string",
+                country: "GB",
+                countrySubDivision: "string",
+              },
+              applicant: true,
+              email: "string",
+              phone: "string",
+              documentInfo: [
+                {
+                  path: "string",
+                  fileName: "string",
+                  uploadedDate: "2017-01-28T01:01:01+0000",
+                },
+              ],
+              additionalIdentifiers: [
+                {
+                  type: "BSN",
+                  value: "string",
+                },
+              ],
+              complianceData: {
+                relationship: "string",
+              },
+            },
+          ],
+          document_info: [
+            {
+              path: "string",
+              fileName: "string",
+              uploadedDate: "2017-01-28T01:01:01+0000",
+            },
+          ],
+          provisional_customer_id: "string",
+          customer_trust: {
+            trustNature: "BARE_TRUSTS",
+          },
+          tax_profile: {
+            taxIdentifier: "string",
+          },
+          idempotency_key: idempotency_key,
+        )
+      end
+
+      it "builds correct request with idempotency headers" do
+        expect(WebMock).to have_requested(:post, %r{/customers}).with(
+          headers: modulr_idempotency_request_headers(idempotency_key),
+          body: {
+            type: "LLC",
+            legalEntity: "GB",
+            externalReference: "My new customer",
+            name: "string",
+            companyRegNumber: "2018123987165432",
+            registeredAddress: {
+              addressLine1: "string",
+              addressLine2: "string",
+              postTown: "string",
+              postCode: "string",
+              country: "GB",
+              countrySubDivision: "string",
+            },
+            tradingAddress: {
+              addressLine1: "string",
+              addressLine2: "string",
+              postTown: "string",
+              postCode: "string",
+              country: "GB",
+              countrySubDivision: "string",
+            },
+            industryCode: "string",
+            tcsVersion: 0,
+            expectedMonthlySpend: 0,
+            associates: [
+              {
+                type: "DIRECTOR",
+                firstName: "string",
+                middleName: "string",
+                lastName: "string",
+                dateOfBirth: "string",
+                ownership: 0,
+                homeAddress: {
+                  addressLine1: "string",
+                  addressLine2: "string",
+                  postTown: "string",
+                  postCode: "string",
+                  country: "GB",
+                  countrySubDivision: "string",
+                },
+                applicant: true,
+                email: "string",
+                phone: "string",
+                documentInfo: [
+                  {
+                    path: "string",
+                    fileName: "string",
+                    uploadedDate: "2017-01-28T01:01:01+0000",
+                  },
+                ],
+                additionalIdentifiers: [
+                  {
+                    type: "BSN",
+                    value: "string",
+                  },
+                ],
+                complianceData: {
+                  relationship: "string",
+                },
+              },
+            ],
+            documentInfo: [
+              {
+                path: "string",
+                fileName: "string",
+                uploadedDate: "2017-01-28T01:01:01+0000",
+              },
+            ],
+            provisionalCustomerId: "string",
+            customerTrust: {
+              trustNature: "BARE_TRUSTS",
+            },
+            taxProfile: {
+              taxIdentifier: "string",
+            },
+          },
+        )
+      end
+
+      it "does not append idempotency_key to the query string" do
+        expect(WebMock).to have_requested(:post, %r{/customers}).with { |req|
+          modulr_request_query_excludes_idempotency_key?(req)
+        }
+      end
+
+      it "returns created customer" do
+        expect(created_customer_with_idempotency).to be_a Modulr::Resources::Customers::Customer
+        expect(created_customer_with_idempotency.external_reference).to eql("My new customer")
+      end
+    end
+
     context "when the type is invalid" do
       before do
         stub_request(:post, %r{/customers}).to_return(

--- a/spec/modulr/api/notifications_service_spec.rb
+++ b/spec/modulr/api/notifications_service_spec.rb
@@ -43,6 +43,56 @@ RSpec.describe Modulr::API::NotificationsService, :unit, type: :client do
       end
     end
 
+    context "when idempotency_key is provided" do
+      before do
+        stub_request(:post, %r{/customers/C2188C26/notifications}).to_return(
+          read_http_response_fixture("notifications/create", "success")
+        )
+        stub_modulr_apikey_env_for_idempotency
+      end
+
+      let(:idempotency_key) { "notification-create-idempotency-xyz" }
+
+      let!(:created_notification_with_idempotency) do
+        notifications.create(
+          customer_id: "C2188C26",
+          type: "PAYOUT",
+          channel: "WEBHOOK",
+          destinations: ["https://foo.bar"],
+          config: { retry: true, secret: "00000000000000000000000000000000", hmac_algorithm: "" },
+          idempotency_key: idempotency_key,
+        )
+      end
+
+      it "builds correct request with idempotency headers" do
+        expect(WebMock).to have_requested(:post, %r{/customers/C2188C26/notifications}).with(
+          headers: modulr_idempotency_request_headers(idempotency_key),
+          body: {
+            type: "PAYOUT",
+            channel: "WEBHOOK",
+            destinations: ["https://foo.bar"],
+            config: { retry: true, secret: "00000000000000000000000000000000", hmac_algorithm: "" },
+          },
+        )
+      end
+
+      it "does not append idempotency_key to the query string" do
+        expect(WebMock).to have_requested(:post, %r{/customers/C2188C26/notifications}).with { |req|
+          modulr_request_query_excludes_idempotency_key?(req)
+        }
+      end
+
+      it "returns the created notification" do
+        expect(created_notification_with_idempotency).to be_a Modulr::Resources::Notifications::Notification
+        expect(created_notification_with_idempotency.id).to eql("W21082VJGX")
+        expect(created_notification_with_idempotency.type).to eql("PAYOUT")
+        expect(created_notification_with_idempotency.channel).to eql("WEBHOOK")
+        expect(created_notification_with_idempotency.status).to eql("ACTIVE")
+        expect(created_notification_with_idempotency.destinations).to include("https://eowmy3fgz2o3b8v.m.pipedream.net")
+        expect(created_notification_with_idempotency.config).to be_a Modulr::Resources::Notifications::Config
+      end
+    end
+
     context "when the secret is invalid" do
       before do
         stub_request(:post, %r{/customers/C2188C26/notifications}).to_return(

--- a/spec/modulr/api/notifications_service_spec.rb
+++ b/spec/modulr/api/notifications_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Modulr::API::NotificationsService, :unit, type: :client do
           channel: "WEBHOOK",
           destinations: ["https://foo.bar"],
           config: { retry: true, secret: "00000000000000000000000000000000", hmac_algorithm: "" },
-          idempotency_key: idempotency_key,
+          idempotency_key: idempotency_key
         )
       end
 
@@ -72,14 +72,16 @@ RSpec.describe Modulr::API::NotificationsService, :unit, type: :client do
             channel: "WEBHOOK",
             destinations: ["https://foo.bar"],
             config: { retry: true, secret: "00000000000000000000000000000000", hmac_algorithm: "" },
-          },
+          }
         )
       end
 
       it "does not append idempotency_key to the query string" do
-        expect(WebMock).to have_requested(:post, %r{/customers/C2188C26/notifications}).with { |req|
-          modulr_request_query_excludes_idempotency_key?(req)
-        }
+        expect(WebMock).to(
+          have_requested(:post, %r{/customers/C2188C26/notifications}).with do |req|
+            modulr_request_query_excludes_idempotency_key?(req)
+          end
+        )
       end
 
       it "returns the created notification" do

--- a/spec/modulr/api/payments_service_spec.rb
+++ b/spec/modulr/api/payments_service_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
             name: "John",
           },
           reference: "Outgoing sepa instant payment",
-          idempotency_key: idempotency_key,
+          idempotency_key: idempotency_key
         )
       end
 
@@ -89,14 +89,16 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
               name: "John",
             },
             reference: "Outgoing sepa instant payment",
-          },
+          }
         )
       end
 
       it "does not append idempotency_key to the query string" do
-        expect(WebMock).to have_requested(:post, %r{/payments}).with { |req|
-          modulr_request_query_excludes_idempotency_key?(req)
-        }
+        expect(WebMock).to(
+          have_requested(:post, %r{/payments}).with do |req|
+            modulr_request_query_excludes_idempotency_key?(req)
+          end
+        )
       end
 
       it "returns created payment" do

--- a/spec/modulr/api/payments_service_spec.rb
+++ b/spec/modulr/api/payments_service_spec.rb
@@ -50,6 +50,60 @@ RSpec.describe Modulr::API::PaymentsService, :unit, type: :client do
         expect(created_payment.approval_status).to eql("NOTNEEDED")
       end
     end
+
+    context "when idempotency_key is provided" do
+      before do
+        stub_request(:post, %r{/payments}).to_return(
+          read_http_response_fixture("payments/create", "success")
+        )
+        stub_modulr_apikey_env_for_idempotency
+      end
+
+      let(:idempotency_key) { "payment-idempotency-abc" }
+
+      let!(:created_payment_with_idempotency) do
+        payments.create(
+          account_id: "A21E68ZZ",
+          currency: "EUR",
+          amount: "148.0",
+          destination: {
+            type: "IBAN",
+            iban: "ES3200810106680006714488",
+            name: "John",
+          },
+          reference: "Outgoing sepa instant payment",
+          idempotency_key: idempotency_key,
+        )
+      end
+
+      it "builds correct request with idempotency headers (x-mod-nonce from HMAC-SHA256)" do
+        expect(WebMock).to have_requested(:post, %r{/payments}).with(
+          headers: modulr_idempotency_request_headers(idempotency_key),
+          body: {
+            sourceAccountId: "A21E68ZZ",
+            currency: "EUR",
+            amount: "148.0",
+            destination: {
+              type: "IBAN",
+              iban: "ES3200810106680006714488",
+              name: "John",
+            },
+            reference: "Outgoing sepa instant payment",
+          },
+        )
+      end
+
+      it "does not append idempotency_key to the query string" do
+        expect(WebMock).to have_requested(:post, %r{/payments}).with { |req|
+          modulr_request_query_excludes_idempotency_key?(req)
+        }
+      end
+
+      it "returns created payment" do
+        expect(created_payment_with_idempotency).to be_a Modulr::Resources::Payments::Payment
+        expect(created_payment_with_idempotency.id).to eql("P210FFRUVT")
+      end
+    end
   end
 
   describe "find payment" do

--- a/spec/modulr/api/services_spec.rb
+++ b/spec/modulr/api/services_spec.rb
@@ -7,5 +7,6 @@ RSpec.describe Modulr::API::Services do
     expect(client.accounts).to be_an_instance_of(Modulr::API::AccountsService)
     expect(client.payments).to be_an_instance_of(Modulr::API::PaymentsService)
     expect(client.transactions).to be_an_instance_of(Modulr::API::TransactionsService)
+    expect(client.customers).to be_an_instance_of(Modulr::API::CustomersService)
   end
 end

--- a/spec/modulr/client_spec.rb
+++ b/spec/modulr/client_spec.rb
@@ -17,8 +17,11 @@ RSpec.describe Modulr::Client, :unit do
       expect(described_class.idempotency_nonce(idempotency_key)).to eq(expected)
     end
 
-    it "is stable for the same inputs" do
-      expect(described_class.idempotency_nonce("same-key")).to eq(described_class.idempotency_nonce("same-key"))
+    it "is deterministic for the same idempotency_key" do
+      key = "same-key"
+      first_nonce = described_class.idempotency_nonce(key)
+      second_nonce = described_class.idempotency_nonce(key)
+      expect(first_nonce).to eq(second_nonce)
     end
   end
 
@@ -35,16 +38,18 @@ RSpec.describe Modulr::Client, :unit do
         headers: {
           "Authorization" => "api_key",
           "Content-Type" => "application/json",
-        },
+        }
       )
     end
 
     it "does not add a query string when no options are passed" do
       client.get("/test")
 
-      expect(WebMock).to have_requested(:get, %r{/test}).with { |req|
-        req.uri.query.nil?
-      }
+      expect(WebMock).to(
+        have_requested(:get, %r{/test}).with do |req|
+          req.uri.query.nil?
+        end
+      )
     end
 
     it "merges options into the query string" do
@@ -54,24 +59,26 @@ RSpec.describe Modulr::Client, :unit do
           filter: "active",
           page: 0,
           limit: 20,
-        },
+        }
       )
 
       expect(WebMock).to have_requested(:get, %r{/test}).with(
         query: hash_including(
           "filter" => "active",
           "page" => "0",
-          "limit" => "20",
-        ),
+          "limit" => "20"
+        )
       )
     end
 
     it "does not send a body" do
       client.get("/test", { q: "x" })
 
-      expect(WebMock).to have_requested(:get, %r{/test}).with { |req|
-        req.body.nil? || req.body.to_s.empty?
-      }
+      expect(WebMock).to(
+        have_requested(:get, %r{/test}).with do |req|
+          req.body.nil? || req.body.to_s.empty?
+        end
+      )
     end
 
     context "when idempotency_key is provided in options" do
@@ -82,19 +89,24 @@ RSpec.describe Modulr::Client, :unit do
       it "does not send x-mod-nonce or x-mod-retry headers" do
         client.get("/test", { q: "a", idempotency_key: idempotency_key })
 
-        expect(WebMock).to have_requested(:get, %r{/test}).with { |req|
-          keys = (req.headers || {}).keys.map { |k| k.to_s.downcase }
-          keys.none? { |k| k == "x-mod-nonce" || k == "x-mod-retry" }
-        }
+        idempotency_header_names = %w[x-mod-nonce x-mod-retry]
+        expect(WebMock).to(
+          have_requested(:get, %r{/test}).with do |req|
+            keys = (req.headers || {}).keys.map { |k| k.to_s.downcase }
+            keys.none? { |k| idempotency_header_names.include?(k) }
+          end
+        )
       end
 
       it "does not include idempotency_key in the query string" do
         client.get("/test", { filter: "x", idempotency_key: idempotency_key })
 
-        expect(WebMock).to have_requested(:get, %r{/test}).with { |req|
-          q = req.uri.query.to_s
-          !q.include?("idempotency") && q.include?("filter")
-        }
+        expect(WebMock).to(
+          have_requested(:get, %r{/test}).with do |req|
+            q = req.uri.query.to_s
+            !q.include?("idempotency") && q.include?("filter")
+          end
+        )
       end
     end
   end
@@ -105,7 +117,7 @@ RSpec.describe Modulr::Client, :unit do
         stub_request(:post, %r{/test}).to_return(
           status: 200,
           body: "{}",
-          headers: { "Content-Type" => "application/json" },
+          headers: { "Content-Type" => "application/json" }
         )
         stub_modulr_apikey_env_for_idempotency
       end
@@ -129,15 +141,17 @@ RSpec.describe Modulr::Client, :unit do
             resource: "example",
             amount: "1.0",
             nested: { type: "A", code: "x" },
-          },
+          }
         )
       end
 
       it "does not put idempotency_key on the query string" do
         client.post("/test", { foo: "bar" }, idempotency_key: idempotency_key)
-        expect(WebMock).to have_requested(:post, %r{/test}).with { |req|
-          modulr_request_query_excludes_idempotency_key?(req)
-        }
+        expect(WebMock).to(
+          have_requested(:post, %r{/test}).with do |req|
+            modulr_request_query_excludes_idempotency_key?(req)
+          end
+        )
       end
     end
   end
@@ -148,7 +162,7 @@ RSpec.describe Modulr::Client, :unit do
         stub_request(:put, %r{/test}).to_return(
           status: 200,
           body: "{}",
-          headers: { "Content-Type" => "application/json" },
+          headers: { "Content-Type" => "application/json" }
         )
         stub_modulr_apikey_env_for_idempotency
       end
@@ -159,7 +173,7 @@ RSpec.describe Modulr::Client, :unit do
         client.put(
           "/test",
           { state: "paused", tags: [], meta: {} },
-          idempotency_key: idempotency_key,
+          idempotency_key: idempotency_key
         )
 
         expect(WebMock).to have_requested(:put, %r{/test}).with(
@@ -168,7 +182,7 @@ RSpec.describe Modulr::Client, :unit do
             state: "paused",
             tags: [],
             meta: {},
-          },
+          }
         )
       end
     end

--- a/spec/modulr/client_spec.rb
+++ b/spec/modulr/client_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "base64"
+require "openssl"
+
+RSpec.describe Modulr::Client, :unit do
+  let(:client) { initialize_client }
+
+  describe ".idempotency_nonce" do
+    before { stub_modulr_apikey_env_for_idempotency("api_key") }
+
+    it "returns url-safe Base64 HMAC-SHA256(idempotency_key) with secret MODULR_APIKEY" do
+      idempotency_key = "client-spec-op-789"
+      expected = Base64.urlsafe_encode64(
+        OpenSSL::HMAC.digest(OpenSSL::Digest.new("SHA256"), "api_key", idempotency_key)
+      )
+      expect(described_class.idempotency_nonce(idempotency_key)).to eq(expected)
+    end
+
+    it "is stable for the same inputs" do
+      expect(described_class.idempotency_nonce("same-key")).to eq(described_class.idempotency_nonce("same-key"))
+    end
+  end
+
+  describe "#get" do
+    before do
+      stub_request(:get, %r{/test})
+        .to_return(status: 200, body: "{}", headers: { "Content-Type" => "application/json" })
+    end
+
+    it "requests the path with sandbox authorization and JSON content type" do
+      client.get("/test")
+
+      expect(WebMock).to have_requested(:get, %r{/test}).with(
+        headers: {
+          "Authorization" => "api_key",
+          "Content-Type" => "application/json",
+        },
+      )
+    end
+
+    it "does not add a query string when no options are passed" do
+      client.get("/test")
+
+      expect(WebMock).to have_requested(:get, %r{/test}).with { |req|
+        req.uri.query.nil?
+      }
+    end
+
+    it "merges options into the query string" do
+      client.get(
+        "/test",
+        {
+          filter: "active",
+          page: 0,
+          limit: 20,
+        },
+      )
+
+      expect(WebMock).to have_requested(:get, %r{/test}).with(
+        query: hash_including(
+          "filter" => "active",
+          "page" => "0",
+          "limit" => "20",
+        ),
+      )
+    end
+
+    it "does not send a body" do
+      client.get("/test", { q: "x" })
+
+      expect(WebMock).to have_requested(:get, %r{/test}).with { |req|
+        req.body.nil? || req.body.to_s.empty?
+      }
+    end
+
+    context "when idempotency_key is provided in options" do
+      before { stub_modulr_apikey_env_for_idempotency }
+
+      let(:idempotency_key) { "get-ignores-idempotency-key" }
+
+      it "does not send x-mod-nonce or x-mod-retry headers" do
+        client.get("/test", { q: "a", idempotency_key: idempotency_key })
+
+        expect(WebMock).to have_requested(:get, %r{/test}).with { |req|
+          keys = (req.headers || {}).keys.map { |k| k.to_s.downcase }
+          keys.none? { |k| k == "x-mod-nonce" || k == "x-mod-retry" }
+        }
+      end
+
+      it "does not include idempotency_key in the query string" do
+        client.get("/test", { filter: "x", idempotency_key: idempotency_key })
+
+        expect(WebMock).to have_requested(:get, %r{/test}).with { |req|
+          q = req.uri.query.to_s
+          !q.include?("idempotency") && q.include?("filter")
+        }
+      end
+    end
+  end
+
+  describe "#post" do
+    context "when idempotency_key is provided in options" do
+      before do
+        stub_request(:post, %r{/test}).to_return(
+          status: 200,
+          body: "{}",
+          headers: { "Content-Type" => "application/json" },
+        )
+        stub_modulr_apikey_env_for_idempotency
+      end
+
+      let(:idempotency_key) { "post-idempotency-client-spec" }
+
+      let(:payload) do
+        {
+          resource: "example",
+          amount: "1.0",
+          nested: { type: "A", code: "x" },
+        }
+      end
+
+      it "sends x-mod-nonce and x-mod-retry derived from idempotency_key" do
+        client.post("/test", payload, idempotency_key: idempotency_key)
+
+        expect(WebMock).to have_requested(:post, %r{/test}).with(
+          headers: modulr_idempotency_request_headers(idempotency_key),
+          body: {
+            resource: "example",
+            amount: "1.0",
+            nested: { type: "A", code: "x" },
+          },
+        )
+      end
+
+      it "does not put idempotency_key on the query string" do
+        client.post("/test", { foo: "bar" }, idempotency_key: idempotency_key)
+        expect(WebMock).to have_requested(:post, %r{/test}).with { |req|
+          modulr_request_query_excludes_idempotency_key?(req)
+        }
+      end
+    end
+  end
+
+  describe "#put" do
+    context "when idempotency_key is provided in options" do
+      before do
+        stub_request(:put, %r{/test}).to_return(
+          status: 200,
+          body: "{}",
+          headers: { "Content-Type" => "application/json" },
+        )
+        stub_modulr_apikey_env_for_idempotency
+      end
+
+      let(:idempotency_key) { "put-idempotency-client-spec" }
+
+      it "sends the same idempotency headers as post" do
+        client.put(
+          "/test",
+          { state: "paused", tags: [], meta: {} },
+          idempotency_key: idempotency_key,
+        )
+
+        expect(WebMock).to have_requested(:put, %r{/test}).with(
+          headers: modulr_idempotency_request_headers(idempotency_key),
+          body: {
+            state: "paused",
+            tags: [],
+            meta: {},
+          },
+        )
+      end
+    end
+  end
+end

--- a/spec/support/idempotency_helpers.rb
+++ b/spec/support/idempotency_helpers.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module ModulrSpec
+  module IdempotencyHelpers
+    DEFAULT_TEST_APIKEY = "api_key"
+
+    def modulr_idempotency_request_headers(idempotency_key, api_key: DEFAULT_TEST_APIKEY)
+      {
+        "Authorization" => api_key,
+        "Content-Type" => "application/json",
+        "x-mod-nonce" => Modulr::Client.idempotency_nonce(idempotency_key),
+        "x-mod-retry" => "true",
+      }
+    end
+
+    def stub_modulr_apikey_env_for_idempotency(api_key = DEFAULT_TEST_APIKEY)
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("MODULR_APIKEY").and_return(api_key)
+    end
+
+    def modulr_request_query_excludes_idempotency_key?(request)
+      q = URI(request.uri).query
+      q.nil? || !q.include?("idempotency")
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include ModulrSpec::IdempotencyHelpers
+end

--- a/spec/support/shared/build_request_spec.rb
+++ b/spec/support/shared/build_request_spec.rb
@@ -10,14 +10,11 @@ RSpec.shared_examples "builds correct request" do |params|
   let(:method) { params[:method].to_sym || :get }
   let(:path) { params[:path] || nil }
   let(:headers) { params[:headers] || default_headers }
-  let(:body) { params[:body] || {} }
   let(:query) { params[:query] || nil }
 
   it "builds correct request" do
-    expect(WebMock).to have_requested(method, path).with(
-      headers: headers,
-      body: body,
-      query: query
-    )
+    expectation = { headers: headers, query: query }
+    expectation[:body] = params[:body] if params.key?(:body)
+    expect(WebMock).to have_requested(method, path).with(**expectation)
   end
 end


### PR DESCRIPTION
Add idempotency key workflow for methods like POST/PUT/DELETE in Modulr to avoid duplicate requests.
More info [here](https://modulr.readme.io/docs/limits-and-errors)

Missing implementation is related to the Modulr requirements about the 48h retrial.

> Do not retry after 48 hours as the request could be executed as a new request after this.

Do we want to control it or let it fail?

