### PR TITLE
Refactor idempotency headers setup in client

### DIFF
--- a/lib/modulr/api/service.rb
+++ b/lib/modulr/api/service.rb
@@ -9,12 +9,6 @@ module Modulr
         @client = client
       end
 
-      def idempotency_headers(options)
-        headers = {}
-        headers[:idempotency_key] = options[:idempotency_key] if options[:idempotency_key]
-        headers
-      end
-
       def format_datetime(datetime)
         datetime.strftime("%Y-%m-%dT%H:%M:%S%z")
       end

--- a/lib/modulr/client.rb
+++ b/lib/modulr/client.rb
@@ -80,28 +80,30 @@ module Modulr
 
     def request_options(method, _path, data, options)
       default_options.tap do |defaults|
+        add_idempotency_headers!(defaults[:headers], method, options)
         add_auth_options!(defaults)
-        add_idempotency_headers!(defaults[:headers], method, options) if options
+
         defaults[:body] = JSON.dump(data) if data
       end
     end
 
     def add_auth_options!(options)
-      return sandbox_auth_options(options) if @base_url.eql?(SANDBOX_URL)
+      return sandbox_auth_options(options[:headers]) if @base_url.eql?(SANDBOX_URL)
 
-      auth_options(options)
+      auth_options(options[:headers])
     end
 
     def sandbox_auth_options(options)
-      options[:headers][:authorization] = @apikey
+      options[:authorization] = @apikey
     end
 
     def auth_options(options)
-      signature = Auth::Signature.calculate(apikey: @apikey, apisecret: @apisecret)
+      nonce = options["x-mod-nonce"]
+      signature = Auth::Signature.calculate(apikey: @apikey, apisecret: @apisecret, nonce: nonce)
 
-      options[:headers][:authorization] = signature.authorization
-      options[:headers][:date] = signature.timestamp
-      options[:headers][:"x-mod-nonce"] ||= signature.nonce
+      options[:authorization] = signature.authorization
+      options[:date] = signature.timestamp
+      options["x-mod-nonce"] = signature.nonce
     end
 
     private def add_idempotency_headers!(headers, method, options)
@@ -111,8 +113,8 @@ module Modulr
       return unless idempotency_key
 
       nonce = self.class.idempotency_nonce(idempotency_key)
-      headers[:"x-mod-nonce"] = nonce
-      headers[:"x-mod-retry"] = "true" if nonce && !nonce.empty?
+      headers["x-mod-nonce"] = nonce
+      headers["x-mod-retry"] = "true"
     end
 
     private def merge_query_params(request, method, options)


### PR DESCRIPTION
Answers from Modulr team:

**Question 1** - Do both x-mod-nonce and x-mod-retry need to be included? 
Yes, this is the expected behaviour. To perform an idempotent retry, you need both headers present:

    x-mod-nonce set to the same value as the original request
    x-mod-retry set to true
    
Without x-mod-retry: true, the system will not treat the request as an intentional retry. A repeated nonce without this flag will result in a permissions/duplication error, which is exactly what you're seeing ({"code":"PERMISSION","message":"Could not complete request"}). This is by design to protect against accidental duplicate submissions. The idempotent response will then be returned for up to 48 hours from the original request. After that window, the nonce can no longer be reused and the request would be treated as new.

**Question 2** - Will idempotency work the same way in production with HMAC authentication? Yes, idempotency behaviour is consistent regardless of the authentication method used. The key thing to be aware of when switching to HMAC is that x-mod-nonce plays a dual role: it is both part of your HMAC signature calculation (included in the signature string alongside the Date header) and your idempotency key. This means that for a retry using the same nonce, your HMAC signature string should be constructed using that same nonce value. Beyond that, the idempotency logic works identically in production as it does in sandbox.


